### PR TITLE
fix: prevent shell injection from VCS metadata

### DIFF
--- a/bitbucket-cloud.jenkinsfile
+++ b/bitbucket-cloud.jenkinsfile
@@ -90,7 +90,6 @@ pipeline {
                     }
                     def failuresList = null
                     try {
-                        def mergeBaseSha = null
                         // find merge base for the PR from Bitbucket REST API
                         def mergeBaseOut = sh(script: 'curl -sS --get \
                                 --url "$BITBUCKET_API_URL/repositories/$REPO_NAME/merge-base/$INFRACOST_VCS_BASE_BRANCH..$INFRACOST_VCS_BRANCH" \
@@ -98,17 +97,17 @@ pipeline {
                                 --header "Accept: application/json"',
                             returnStdout: true).trim()
                         def mergeBaseDetails = readJSON text: mergeBaseOut
-                        mergeBaseSha = mergeBaseDetails.hash
+                        env.MERGE_BASE_SHA = mergeBaseDetails.hash
 
-                        echo "Found merge base SHA: ${mergeBaseSha}"
+                        echo "Found merge base SHA: ${env.MERGE_BASE_SHA}"
 
                         // Clone the repository to a temporary directory
-                        sh "git clone --depth 1 -b ${env.INFRACOST_VCS_BRANCH} $BITBUCKET_GIT_ORIGIN /tmp/repo"
+                        sh 'git clone --depth 1 --branch "$INFRACOST_VCS_BRANCH" "$BITBUCKET_GIT_ORIGIN" /tmp/repo'
 
                         echo "Generating Infracost baseline from merge base"
 
                         // Checkout the merge base commit
-                        sh "cd /tmp/repo && git fetch --depth 1 origin ${mergeBaseSha} && git checkout -q ${mergeBaseSha}"
+                        sh 'cd /tmp/repo && git fetch --depth 1 origin "$MERGE_BASE_SHA" && git checkout --quiet --detach "$MERGE_BASE_SHA"'
 
                         sh 'infracost breakdown --path=/tmp/repo \
                             --format=json \
@@ -118,7 +117,7 @@ pipeline {
 
                         echo "Generating Infracost diff"
 
-                        sh "cd /tmp/repo && git checkout ${env.INFRACOST_VCS_BRANCH}"
+                        sh 'cd /tmp/repo && git checkout --detach "$INFRACOST_VCS_BRANCH"'
 
                         // Generate an Infracost diff and save it to a JSON file.
                         sh 'infracost diff --path=/tmp/repo \
@@ -183,7 +182,7 @@ pipeline {
                         echo "Generating Infracost baseline for default branch"
 
                         // Clone the repository to a temporary directory
-                        sh "git clone --depth 1 -b ${env.BRANCH_NAME} $BITBUCKET_GIT_ORIGIN /tmp/repo && cd /tmp/repo"
+                        sh 'git clone --depth 1 --branch "$BRANCH_NAME" "$BITBUCKET_GIT_ORIGIN" /tmp/repo'
 
                         // Run Infracost breakdown, don't use the TF_VAR_FILE so all projects in the repo are evaluated
                         sh 'infracost breakdown --path=/tmp/repo \

--- a/bitbucket-server.jenkinsfile
+++ b/bitbucket-server.jenkinsfile
@@ -99,7 +99,6 @@ pipeline {
                     }
                     def failuresList = null
                     try {
-                        def mergeBaseSha = null
                         // find merge base for the PR from Bitbucket server REST API
                         //
                         // NOTE: the following curl needs to be tested with your Bitbucket server version,
@@ -113,17 +112,17 @@ pipeline {
                             returnStdout: true).trim()
                         def mergeBaseDetails = readJSON text: mergeBaseOut
                         echo "Bitbucket API response for mergeBaseDetails: ${mergeBaseDetails}" // Delete this line after debugging
-                        mergeBaseSha = mergeBaseDetails.id
+                        env.MERGE_BASE_SHA = mergeBaseDetails.id
 
-                        echo "Found merge base SHA: ${mergeBaseSha}"
+                        echo "Found merge base SHA: ${env.MERGE_BASE_SHA}"
 
                         // Clone the repository to a temporary directory
-                        sh "git clone --depth 1 -b ${env.INFRACOST_VCS_BRANCH} $BITBUCKET_GIT_ORIGIN /tmp/repo"
+                        sh 'git clone --depth 1 --branch "$INFRACOST_VCS_BRANCH" "$BITBUCKET_GIT_ORIGIN" /tmp/repo'
 
                         echo "Generating Infracost baseline from merge base"
 
                         // Checkout the merge base commit
-                        sh "cd /tmp/repo && git fetch --depth 1 origin ${mergeBaseSha} && git checkout -q ${mergeBaseSha}"
+                        sh 'cd /tmp/repo && git fetch --depth 1 origin "$MERGE_BASE_SHA" && git checkout --quiet --detach "$MERGE_BASE_SHA"'
 
                         sh 'infracost breakdown --path=/tmp/repo \
                             --format=json \
@@ -133,7 +132,7 @@ pipeline {
 
                         echo "Generating Infracost diff"
 
-                        sh "cd /tmp/repo && git checkout ${env.INFRACOST_VCS_BRANCH}"
+                        sh 'cd /tmp/repo && git checkout --detach "$INFRACOST_VCS_BRANCH"'
 
                         // Generate an Infracost diff and save it to a JSON file.
                         sh 'infracost diff --path=/tmp/repo \
@@ -198,7 +197,7 @@ pipeline {
                         echo "Generating Infracost baseline for default branch"
 
                         // Clone the repository to a temporary directory
-                        sh "git clone --depth 1 -b ${env.BRANCH_NAME} $BITBUCKET_GIT_ORIGIN /tmp/repo && cd /tmp/repo"
+                        sh 'git clone --depth 1 --branch "$BRANCH_NAME" "$BITBUCKET_GIT_ORIGIN" /tmp/repo'
 
                         // Run Infracost breakdown, don't use the TF_VAR_FILE so all projects in the repo are evaluated
                         sh 'infracost breakdown --path=/tmp/repo \

--- a/github.jenkinsfile
+++ b/github.jenkinsfile
@@ -46,17 +46,17 @@ pipeline {
 
                 script {
                     // Get the default branch of the repository
-                    def repoApiUrl = "${env.GITHUB_API_URL}/repos/${env.REPO_NAME}"
-                    echo "Getting repo details from GitHub API: ${repoApiUrl}"
-                    def repoOutput = sh(script: 'curl -s -H \"Authorization: token $GITHUB_TOKEN\" \"' + repoApiUrl + '\"', returnStdout: true).trim()
+                    env.REPO_API_URL = "${env.GITHUB_API_URL}/repos/${env.REPO_NAME}"
+                    echo "Getting repo details from GitHub API: ${env.REPO_API_URL}"
+                    def repoOutput = sh(script: 'curl -sS -H "Authorization: token $GITHUB_TOKEN" "$REPO_API_URL"', returnStdout: true).trim()
                     def repoDetails = readJSON text: repoOutput
                     def defaultBranch = repoDetails.default_branch
                     env.DEFAULT_BRANCH = defaultBranch
 
                     // Call GitHub API to get branch details
-                    def branchApiUrl = "${env.GITHUB_API_URL}/repos/${env.REPO_NAME}/branches/${env.BRANCH_NAME}"
-                    echo "Getting branch details from GitHub API: ${branchApiUrl}"
-                    def output = sh(script: 'curl -s -H \"Authorization: token $GITHUB_TOKEN\" \"' + branchApiUrl + '\"', returnStdout: true).trim()
+                    env.BRANCH_API_URL = "${env.GITHUB_API_URL}/repos/${env.REPO_NAME}/branches/${env.BRANCH_NAME}"
+                    echo "Getting branch details from GitHub API: ${env.BRANCH_API_URL}"
+                    def output = sh(script: 'curl -sS -H "Authorization: token $GITHUB_TOKEN" "$BRANCH_API_URL"', returnStdout: true).trim()
                     def branchDetails = readJSON text: output
 
                     // Set branch and repository environment variables
@@ -82,19 +82,19 @@ pipeline {
                     env.INFRACOST_VCS_BASE_BRANCH = env.DEFAULT_BRANCH
 
                     // Get the merge base SHA using GitHub API
-                    def mergeBaseApiUrl = "${env.GITHUB_API_URL}/repos/${env.REPO_NAME}/compare/${env.DEFAULT_BRANCH}...${env.BRANCH_NAME}"
-                    echo "Getting merge base details from GitHub API: ${mergeBaseApiUrl}"
-                    def mergeBaseOutput = sh(script: 'curl -s -H \"Authorization: token $GITHUB_TOKEN\" \"' + mergeBaseApiUrl + '\"', returnStdout: true).trim()
+                    env.MERGE_BASE_API_URL = "${env.GITHUB_API_URL}/repos/${env.REPO_NAME}/compare/${env.DEFAULT_BRANCH}...${env.BRANCH_NAME}"
+                    echo "Getting merge base details from GitHub API: ${env.MERGE_BASE_API_URL}"
+                    def mergeBaseOutput = sh(script: 'curl -sS -H "Authorization: token $GITHUB_TOKEN" "$MERGE_BASE_API_URL"', returnStdout: true).trim()
                     def mergeBaseDetails = readJSON text: mergeBaseOutput
-                    def mergeBaseSha = mergeBaseDetails.merge_base_commit.sha
+                    env.MERGE_BASE_SHA = mergeBaseDetails.merge_base_commit.sha
 
-                    echo "Found merge base SHA: ${mergeBaseSha}"
+                    echo "Found merge base SHA: ${env.MERGE_BASE_SHA}"
 
                     // Clone the repository to a temporary directory
-                    sh "git clone --depth 1 -b ${env.INFRACOST_VCS_COMMIT_SHA} ${GITHUB_URL}/${env.REPO_NAME}.git /tmp/repo"
+                    sh 'git clone --depth 1 --branch "$INFRACOST_VCS_COMMIT_SHA" "$GITHUB_URL/$REPO_NAME.git" /tmp/repo'
 
                     // Checkout the merge base commit
-                    sh "cd /tmp/repo && git fetch --depth 1 origin ${mergeBaseSha} && git checkout -q ${mergeBaseSha}"
+                    sh 'cd /tmp/repo && git fetch --depth 1 origin "$MERGE_BASE_SHA" && git checkout --quiet --detach "$MERGE_BASE_SHA"'
 
                     sh 'infracost breakdown --path=/tmp/repo \
                         --format=json \
@@ -104,7 +104,7 @@ pipeline {
 
                     echo "Generating Infracost diff"
 
-                    sh "cd /tmp/repo && git checkout ${env.INFRACOST_VCS_COMMIT_SHA}"
+                    sh 'cd /tmp/repo && git checkout --detach "$INFRACOST_VCS_COMMIT_SHA"'
 
                     // Generate an Infracost diff and save it to a JSON file.
                     sh 'infracost diff --path=/tmp/repo \
@@ -158,7 +158,7 @@ pipeline {
                     echo "Generating Infracost baseline for default branch"
 
                     // Clone the repository to a temporary directory
-                    sh "git clone --depth 1 -b ${env.DEFAULT_BRANCH} ${GITHUB_URL}/${env.REPO_NAME}.git /tmp/repo && cd /tmp/repo"
+                    sh 'git clone --depth 1 --branch "$DEFAULT_BRANCH" "$GITHUB_URL/$REPO_NAME.git" /tmp/repo'
 
                     // For cases where you use pull requests in your workflow, we need to add a step here
                     // that updates the PR status in Infracost Cloud based on the PR number from the git log.


### PR DESCRIPTION
Branch and repository metadata can contain shell syntax while remaining valid VCS values. Passing them through quoted environment variables prevents Jenkins Groovy interpolation from turning that metadata into executable shell source while preserving existing integration behavior.